### PR TITLE
Fix for OLINGO-686

### DIFF
--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/uri/UriParserImpl.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/uri/UriParserImpl.java
@@ -79,6 +79,7 @@ public class UriParserImpl extends UriParser {
       .compile("(?:([^.()]+)\\.)?([^.()]+)(?:\\((.+)\\)|(\\(\\)))?");
   private static final Pattern NAVIGATION_SEGMENT_PATTERN = Pattern.compile("([^()]+)(?:\\((.+)\\)|(\\(\\)))?");
   private static final Pattern NAMED_VALUE_PATTERN = Pattern.compile("(?:([^=]+)=)?([^=]+)");
+  private static final Pattern STRING_KEY_PATTERN = Pattern.compile("'([^']*)'");
 
   private final Edm edm;
   private final EdmSimpleTypeFacade simpleTypeFacade;
@@ -446,8 +447,9 @@ public class UriParserImpl extends UriParser {
     ArrayList<EdmProperty> parsedKeyProperties = new ArrayList<EdmProperty>();
     ArrayList<KeyPredicate> keyPredicates = new ArrayList<KeyPredicate>();
 
-    for (final String key : keyPredicate.split(",", -1)) {
-
+    Matcher keyMatcher = STRING_KEY_PATTERN.matcher(keyPredicate);
+    String[] keys = keyMatcher.matches() ? new String[] { keyPredicate }: keyPredicate.split(",", -1);
+    for (final String key : keys) {
       final Matcher matcher = NAMED_VALUE_PATTERN.matcher(key);
       if (!matcher.matches()) {
         throw new UriSyntaxException(UriSyntaxException.INVALIDKEYPREDICATE.addContent(keyPredicate));

--- a/odata2-lib/odata-core/src/test/java/org/apache/olingo/odata2/core/uri/UriParserTest.java
+++ b/odata2-lib/odata-core/src/test/java/org/apache/olingo/odata2/core/uri/UriParserTest.java
@@ -252,6 +252,18 @@ public class UriParserTest extends BaseTest {
     assertEquals("1", result.getKeyPredicates().get(0).getLiteral());
     assertEquals("EmployeeId", result.getKeyPredicates().get(0).getProperty().getName());
   }
+  
+  @Test
+  public void parseEmployeesEntityWithKeyWithComma() throws Exception {
+    UriInfoImpl result = parse("/Employees('1,2')");
+    assertNull(result.getEntityContainer().getName());
+    assertEquals("Employees", result.getTargetEntitySet().getName());
+    assertEquals(UriType.URI2, result.getUriType());
+
+    assertEquals(1, result.getKeyPredicates().size());
+    assertEquals("1,2", result.getKeyPredicates().get(0).getLiteral());
+    assertEquals("EmployeeId", result.getKeyPredicates().get(0).getProperty().getName());
+  }
 
   @Test
   public void parseEmployeesEntityWithKeyEncoded() throws Exception {


### PR DESCRIPTION
Proposing this fix for OLINGO-686 to fix a parse error when key predicates contain a comma (e.g. Employee('1,2'))