### PR TITLE
Allow customisation of ODataJPAFactory singleton

### DIFF
--- a/odata2-jpa-processor/jpa-api/src/main/java/org/apache/olingo/odata2/jpa/processor/api/factory/ODataJPAFactory.java
+++ b/odata2-jpa-processor/jpa-api/src/main/java/org/apache/olingo/odata2/jpa/processor/api/factory/ODataJPAFactory.java
@@ -41,7 +41,8 @@ public abstract class ODataJPAFactory {
 
   private static final String IMPLEMENTATION =
       "org.apache.olingo.odata2.jpa.processor.core.factory.ODataJPAFactoryImpl";
-  private static ODataJPAFactory factoryImpl;
+
+  private static volatile ODataJPAFactory factoryImpl;
 
   /**
    * Method creates a factory instance. The instance returned is singleton.
@@ -101,5 +102,15 @@ public abstract class ODataJPAFactory {
   public ODataJPAAccessFactory getODataJPAAccessFactory() {
     return null;
   };
+
+  /**
+   * Sets the ODataJPAFactory singleton instance to use. This can be used
+   * to override the default behaviour.
+   * @param factoryImpl
+   *            the factoryImpl to set
+   */
+  public static void setFactoryImpl(final ODataJPAFactory factoryImpl) {
+    ODataJPAFactory.factoryImpl = factoryImpl;
+  }
 
 }


### PR DESCRIPTION
Currently it requires forking multiple classes to provide custom
behaviour when using olingo with JPA. Allow setting a custom
ODataJPAFactory which can then return other custom factories as needed.