### PR TITLE
[OLINGO-901] Set osgi range for gson to include 2.2

### DIFF
--- a/odata2-lib/odata-core/pom.xml
+++ b/odata2-lib/odata-core/pom.xml
@@ -74,6 +74,7 @@
 						<Import-Package>
 							javax.ws.rs,
 							javax.ws.rs.*,
+							com.google.gson.*;version="[2.2,$(version;+;${gson.version}))",
 							*
 						</Import-Package>
 						<Export-Package>


### PR DESCRIPTION
OLINGO-827 changed the gson version to 2.4 which causes the maven bundle
plugin to set the lower range for gson to 2.4.