### PR TITLE
[OLINGO-994] Xml content element is not compatible with WCF OData client

### DIFF
--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/ep/producer/AtomEntryEntityProducer.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/ep/producer/AtomEntryEntityProducer.java
@@ -406,10 +406,9 @@ public class AtomEntryEntityProducer {
         mediaResourceMimeType = ContentType.APPLICATION_OCTET_STREAM.toString();
       }
 
-      writer.writeStartElement(FormatXml.ATOM_CONTENT);
+      writer.writeEmptyElement(FormatXml.ATOM_CONTENT);
       writer.writeAttribute(FormatXml.ATOM_TYPE, mediaResourceMimeType);
       writer.writeAttribute(FormatXml.ATOM_SRC, self);
-      writer.writeEndElement();
     } catch (XMLStreamException e) {
       throw new EntityProviderProducerException(EntityProviderException.COMMON, e);
     }


### PR DESCRIPTION
Content element should not have value if src attribute is defined.