### PR TITLE
[OLINGO-1219] Fix NullPointerException if given input is null

### DIFF
--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/commons/Encoder.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/commons/Encoder.java
@@ -96,7 +96,12 @@ public class Encoder {
    */
   private String encodeInternal(final String input) {
     StringBuilder resultStr = new StringBuilder();
-
+    
+    // avoid NPE if the given input is null
+    if (input == null) {
+        return null;
+    }
+    
     try {
       for (byte utf8Byte : input.getBytes("UTF-8")) {
         final char character = (char) utf8Byte;

--- a/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/edm/EdmDateTimeOffset.java
+++ b/odata2-lib/odata-core/src/main/java/org/apache/olingo/odata2/core/edm/EdmDateTimeOffset.java
@@ -157,6 +157,13 @@ public class EdmDateTimeOffset extends AbstractSimpleType {
     } else if (value instanceof Long) {
       milliSeconds = (Long) value;
       offset = 0;
+    } else if (value instanceof Instant) {
+      try {
+        milliSeconds = ((Instant) value).toEpochMilli();
+      } catch (ArithmeticException e) { // in case the Instant is far away from epoch
+        milliSeconds = Long.MAX_VALUE;
+      }
+      offset = 0;
     } else {
       throw new EdmSimpleTypeException(EdmSimpleTypeException.VALUE_TYPE_NOT_SUPPORTED.addContent(value.getClass()));
     }


### PR DESCRIPTION
in current Encoder implementation, if given input is null, an NPE would be thrown

The scenario would be, consider an Entity which key is allowed to be null in Edmx, thus, the data retrieved in data source would be a HashMap only with non-null value, when createEntryKey<-createSelfLink, we generate the key representation from the given data, some of the key would be null and passed to Encoder, which would throw NullPointerException