### PR TITLE
Bump gson to 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <log4j.version>1.2.17</log4j.version>
         <commonscodec.version>1.6</commonscodec.version>
         <commonslang.version>3.1</commonslang.version>
-        <gson.version>2.4</gson.version>
+        <gson.version>2.8.9</gson.version>
 
 		<antlr.version>3.4</antlr.version>
 


### PR DESCRIPTION
Hi @mibo !

This pull request removes CVE-2022-25647 https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647

Best regards

Daniel